### PR TITLE
Ensure that Atom dates are properly serialized as RFC 3339

### DIFF
--- a/src/Atom/AtomConverter.cs
+++ b/src/Atom/AtomConverter.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Xml;
 
-namespace Microsoft.SyndicationFeed
+namespace Microsoft.SyndicationFeed.Atom
 {
-    static class Converter
+    static class AtomConverter
     {
         public static bool TryParseValue<T>(string value, out T result)
         {
@@ -90,7 +91,7 @@ namespace Microsoft.SyndicationFeed
             if (type == typeof(DateTimeOffset))
             {
                 DateTimeOffset dto = (DateTimeOffset)(object)value;
-                return dto.ToString("r");
+                return XmlConvert.ToString(dto.UtcDateTime, XmlDateTimeSerializationMode.Utc);
             }
 
             //
@@ -98,7 +99,7 @@ namespace Microsoft.SyndicationFeed
             if (type == typeof(DateTime))
             {
                 DateTimeOffset dto = new DateTimeOffset((DateTime)(object)value);
-                return dto.ToString("r");
+                return XmlConvert.ToString(dto.UtcDateTime, XmlDateTimeSerializationMode.Utc);
             }
 
             //

--- a/src/Atom/AtomFormatter.cs
+++ b/src/Atom/AtomFormatter.cs
@@ -78,7 +78,7 @@ namespace Microsoft.SyndicationFeed.Atom
 
         public virtual string FormatValue<T>(T value)
         {
-            return Converter.FormatValue(value);
+            return AtomConverter.FormatValue(value);
         }
 
         public virtual ISyndicationContent CreateContent(ISyndicationLink link)

--- a/src/Atom/AtomParser.cs
+++ b/src/Atom/AtomParser.cs
@@ -93,7 +93,7 @@ namespace Microsoft.SyndicationFeed.Atom
 
         public virtual bool TryParseValue<T>(string value, out T result)
         {
-            return Converter.TryParseValue<T>(value, out result);
+            return AtomConverter.TryParseValue<T>(value, out result);
         }
 
         public virtual ISyndicationCategory CreateCategory(ISyndicationContent content)

--- a/src/Rss/RssConverter.cs
+++ b/src/Rss/RssConverter.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.SyndicationFeed.Rss
+{
+    static class RssConverter
+    {
+        public static bool TryParseValue<T>(string value, out T result)
+        {
+            result = default(T);
+
+            Type type = typeof(T);
+
+            //
+            // String
+            if (type == typeof(string))
+            {
+                result = (T)(object)value;
+                return true;
+            }
+
+            if (value == null)
+            {
+                return false;
+            }
+
+            //
+            // DateTimeOffset
+            if (type == typeof(DateTimeOffset))
+            {
+                if (DateTimeUtils.TryParseDate(value, out DateTimeOffset dt))
+                {
+                    result = (T)(object)dt;
+                    return true;
+                }
+
+                return false;
+            }
+
+            //
+            // DateTime
+            if (type == typeof(DateTime))
+            {
+                if (DateTimeUtils.TryParseDate(value, out DateTimeOffset dt))
+                {
+                    result = (T)(object) dt.DateTime;
+                    return true;
+                }
+
+                return false;
+            }
+
+            //
+            // TODO: being added in netstandard 2.0
+            //if (type.GetTypeInfo().IsEnum)
+            //{
+            //    if (Enum.TryParse(typeof(T), value, true, out T o)) {
+            //        result = (T)(object)o;
+            //        return true;
+            //    }
+            //}
+
+            //
+            // Uri
+            if (type == typeof(Uri))
+            {
+                if (UriUtils.TryParse(value, out Uri uri))
+                {
+                    result = (T)(object)uri;
+                    return true;
+                }
+
+                return false;
+            }
+
+            //
+            // Fall back default
+            return (result = (T)Convert.ChangeType(value, typeof(T))) != null;
+        }
+
+        public static string FormatValue<T>(T value)
+        {
+            Type type = typeof(T);
+            
+            //
+            // DateTimeOffset
+            if (type == typeof(DateTimeOffset))
+            {
+                DateTimeOffset dto = (DateTimeOffset)(object)value;
+                return dto.ToString("r");
+            }
+
+            //
+            // DateTime
+            if (type == typeof(DateTime))
+            {
+                DateTimeOffset dto = new DateTimeOffset((DateTime)(object)value);
+                return dto.ToString("r");
+            }
+
+            //
+            // Default
+            return value.ToString();
+        }
+    }
+}

--- a/src/Rss/RssFormatter.cs
+++ b/src/Rss/RssFormatter.cs
@@ -83,7 +83,7 @@ namespace Microsoft.SyndicationFeed.Rss
 
         public virtual string FormatValue<T>(T value)
         {
-            return Converter.FormatValue(value);
+            return RssConverter.FormatValue(value);
         }
 
         public virtual ISyndicationContent CreateContent(ISyndicationLink link)

--- a/src/Rss/RssParser.cs
+++ b/src/Rss/RssParser.cs
@@ -94,7 +94,7 @@ namespace Microsoft.SyndicationFeed.Rss
 
         public virtual bool TryParseValue<T>(string value, out T result)
         {
-            return Converter.TryParseValue<T>(value, out result);
+            return RssConverter.TryParseValue<T>(value, out result);
         }
 
         public virtual ISyndicationItem CreateItem(ISyndicationContent content)

--- a/tests/AtomWriter.cs
+++ b/tests/AtomWriter.cs
@@ -163,7 +163,7 @@ namespace Microsoft.SyndicationFeed.Tests.Atom
             }
 
             string res = sw.ToString();
-            Assert.True(CheckResult(res, $"<entry><id>{entry.Id}</id><title>{entry.Title}</title><updated>{entry.LastUpdated.ToString("r")}</updated><link href=\"{link.Uri}\" /><link title=\"{enclosure.Title}\" href=\"{enclosure.Uri}\" rel=\"{enclosure.RelationshipType}\" type=\"{enclosure.MediaType}\" length=\"{enclosure.Length}\" /><link href=\"{related.Uri}\" rel=\"{related.RelationshipType}\" /><source><title>{source.Title}</title><link href=\"{source.Uri}\" /><updated>{source.LastUpdated.ToString("r")}</updated></source><link href=\"{self.Uri}\" rel=\"{self.RelationshipType}\" /><author><name>{author.Name}</name><email>{author.Email}</email></author><category term=\"{category.Name}\" /><content type=\"{entry.ContentType}\">{entry.Description}</content><summary>{entry.Summary}</summary><rights>{entry.Rights}</rights></entry>"));
+            Assert.True(CheckResult(res, $"<entry><id>{entry.Id}</id><title>{entry.Title}</title><updated>{XmlConvert.ToString(entry.LastUpdated.UtcDateTime, XmlDateTimeSerializationMode.Utc)}</updated><link href=\"{link.Uri}\" /><link title=\"{enclosure.Title}\" href=\"{enclosure.Uri}\" rel=\"{enclosure.RelationshipType}\" type=\"{enclosure.MediaType}\" length=\"{enclosure.Length}\" /><link href=\"{related.Uri}\" rel=\"{related.RelationshipType}\" /><source><title>{source.Title}</title><link href=\"{source.Uri}\" /><updated>{XmlConvert.ToString(source.LastUpdated.UtcDateTime, XmlDateTimeSerializationMode.Utc)}</updated></source><link href=\"{self.Uri}\" rel=\"{self.RelationshipType}\" /><author><name>{author.Name}</name><email>{author.Email}</email></author><category term=\"{category.Name}\" /><content type=\"{entry.ContentType}\">{entry.Description}</content><summary>{entry.Summary}</summary><rights>{entry.Rights}</rights></entry>"));
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace Microsoft.SyndicationFeed.Tests.Atom
             }
 
             string res = sw.ToString();
-            Assert.True(CheckResult(res, $"<title>{title}</title><id>{id}</id><updated>{updated.ToString("r")}</updated>"));
+            Assert.True(CheckResult(res, $"<title>{title}</title><id>{id}</id><updated>{XmlConvert.ToString(updated.UtcDateTime, XmlDateTimeSerializationMode.Utc)}</updated>"));
         }
 
         [Fact]
@@ -277,7 +277,7 @@ namespace Microsoft.SyndicationFeed.Tests.Atom
             }
 
             string res = sw.ToString();
-            Assert.True(res.Contains($"<atom:entry><atom:id>{entry.Id}</atom:id><atom:title>{entry.Title}</atom:title><atom:updated>{entry.LastUpdated.ToString("r")}</atom:updated><atom:author><atom:name>{author.Name}</atom:name><atom:email>{author.Email}</atom:email></atom:author><atom:content>{entry.Description}</atom:content></atom:entry>"));
+            Assert.True(res.Contains($"<atom:entry><atom:id>{entry.Id}</atom:id><atom:title>{entry.Title}</atom:title><atom:updated>{XmlConvert.ToString(entry.LastUpdated.UtcDateTime, XmlDateTimeSerializationMode.Utc)}</atom:updated><atom:author><atom:name>{author.Name}</atom:name><atom:email>{author.Email}</atom:email></atom:author><atom:content>{entry.Description}</atom:content></atom:entry>"));
         }
 
         [Fact]


### PR DESCRIPTION
As mentioned in https://github.com/dotnet/SyndicationFeedReaderWriter/issues/10, dates in Atom feeds need to be serialized in RFC 3339 format.

To do so, I created a separate static Converter class for Atom and for RSS.

Tests have been updated and are passing.