### PR TITLE
Fix typo in exception message in Atom Feed Reader

### DIFF
--- a/src/Atom/AtomFeedReader.cs
+++ b/src/Atom/AtomFeedReader.cs
@@ -89,7 +89,7 @@ namespace Microsoft.SyndicationFeed.Atom
             }
             else
             {
-                throw new XmlException("Unkown Atom Feed");
+                throw new XmlException("Unknown Atom Feed");
             }
         }
     }


### PR DESCRIPTION
Little fix on a typo in the Exception message when parsing an invalid Atom feed.