### PR TITLE
Added ability to have NULL Uris. I write an application that can

### DIFF
--- a/examples/CreateSimpleRssFeedExample.cs
+++ b/examples/CreateSimpleRssFeedExample.cs
@@ -5,6 +5,7 @@
 using Microsoft.SyndicationFeed;
 using Microsoft.SyndicationFeed.Rss;
 using System;
+using System.Text;
 using System.IO;
 using System.Threading.Tasks;
 using System.Xml;

--- a/examples/RssWriteItemWithCustomElementExample.cs
+++ b/examples/RssWriteItemWithCustomElementExample.cs
@@ -5,6 +5,7 @@
 using Microsoft.SyndicationFeed;
 using Microsoft.SyndicationFeed.Rss;
 using System;
+using System.Text;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Rss/RssParser.cs
+++ b/src/Rss/RssParser.cs
@@ -11,6 +11,11 @@ namespace Microsoft.SyndicationFeed.Rss
 {
     public class RssParser : ISyndicationFeedParser
     {
+        public bool AllowNullLinks { get; set; }
+
+        public RssParser() { }
+        public RssParser(bool AllowNullLinks) => this.AllowNullLinks = AllowNullLinks;
+
         public ISyndicationCategory ParseCategory(string value)
         {
             ISyndicationContent content = ParseContent(value);
@@ -193,6 +198,10 @@ namespace Microsoft.SyndicationFeed.Rss
             }
 
             //
+            // Reserve for possible empty url
+            bool isNullUri = false;
+
+            //
             // Title
             string title = content.Value;
 
@@ -203,19 +212,17 @@ namespace Microsoft.SyndicationFeed.Rss
 
             if (url != null)
             {
-                if (!TryParseValue(url, out uri))
-                {
-                    throw new FormatException("Invalid url attribute");
-                }
+                isNullUri = !TryParseValue(url, out uri);
             }
             else
             {
-                if (!TryParseValue(content.Value, out uri))
-                {
-                    throw new FormatException("Invalid url");
-                }
-
+                isNullUri = !TryParseValue(content.Value, out uri);
                 title = null;
+            }
+
+            if (!AllowNullLinks && isNullUri)
+            {
+                throw new FormatException("Invalid url");
             }
 
             //

--- a/src/SyndicationLink.cs
+++ b/src/SyndicationLink.cs
@@ -10,7 +10,7 @@ namespace Microsoft.SyndicationFeed
     {
         public SyndicationLink(Uri url, string relationshipType = null)
         {
-            Uri = url ?? throw new ArgumentNullException(nameof(url));
+            Uri = url;
             RelationshipType = relationshipType;
         }
 


### PR DESCRIPTION
I sometimes encounter empty URI link attributes within items in the feed. I want to be able to handle these RSS feeds without causing a parse error since the rest of the content is valid.